### PR TITLE
Changes to enable compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,14 @@
 	</dependencies>
 
 	<build>
-		<pluginManagement><plugins>
+	  <pluginManagement><plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
 			<!-- Configure Unit tests: do not impose tests to pass to build jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/math/geom2d/Box2D.java
+++ b/src/main/java/math/geom2d/Box2D.java
@@ -130,10 +130,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
     	double y1 = p1.y();
     	double x2 = p2.x();
     	double y2 = p2.y();
-        this.xmin = min(x1, x2);
-        this.xmax = max(x1, x2);
-        this.ymin = min(y1, y2);
-        this.ymax = max(y1, y2);
+        this.xmin = Math.min(x1, x2);
+        this.xmax = Math.max(x1, x2);
+        this.ymin = Math.min(y1, y2);
+        this.ymax = Math.max(y1, y2);
     }
 
     /** Constructor from a point, a width and an height */
@@ -453,10 +453,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
      * @return a new Box2D
      */
     public Box2D union(Box2D box) {
-        double xmin = min(this.xmin, box.xmin);
-        double xmax = max(this.xmax, box.xmax);
-        double ymin = min(this.ymin, box.ymin);
-        double ymax = max(this.ymax, box.ymax);
+        double xmin = Math.min(this.xmin, box.xmin);
+        double xmax = Math.max(this.xmax, box.xmax);
+        double ymin = Math.min(this.ymin, box.ymin);
+        double ymax = Math.max(this.ymax, box.ymax);
         return new Box2D(xmin, xmax, ymin, ymax);
     }
 
@@ -468,10 +468,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
      * @return a new Box2D
      */
     public Box2D intersection(Box2D box) {
-        double xmin = max(this.xmin, box.xmin);
-        double xmax = min(this.xmax, box.xmax);
-        double ymin = max(this.ymin, box.ymin);
-        double ymax = min(this.ymax, box.ymax);
+        double xmin = Math.max(this.xmin, box.xmin);
+        double xmax = Math.min(this.xmax, box.xmax);
+        double ymin = Math.max(this.ymin, box.ymin);
+        double ymax = Math.min(this.ymax, box.ymax);
         return new Box2D(xmin, xmax, ymin, ymax);
     }
 
@@ -482,10 +482,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
      * @return this
      */
     public Box2D merge(Box2D box) {
-        this.xmin = min(this.xmin, box.xmin);
-        this.xmax = max(this.xmax, box.xmax);
-        this.ymin = min(this.ymin, box.ymin);
-        this.ymax = max(this.ymax, box.ymax);
+        this.xmin = Math.min(this.xmin, box.xmin);
+        this.xmax = Math.max(this.xmax, box.xmax);
+        this.ymin = Math.min(this.ymin, box.ymin);
+        this.ymax = Math.max(this.ymax, box.ymax);
         return this;
     }
 
@@ -496,10 +496,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
      * @return the clipped box
      */
     public Box2D clip(Box2D box) {
-        this.xmin = max(this.xmin, box.xmin);
-        this.xmax = min(this.xmax, box.xmax);
-        this.ymin = max(this.ymin, box.ymin);
-        this.ymax = min(this.ymax, box.ymax);
+        this.xmin = Math.max(this.xmin, box.xmin);
+        this.xmax = Math.min(this.xmax, box.xmax);
+        this.ymin = Math.max(this.ymin, box.ymin);
+        this.ymax = Math.min(this.ymax, box.ymax);
         return this;
     }
 
@@ -521,10 +521,10 @@ public class Box2D implements GeometricObject2D, Cloneable {
     	// update bounds with coordinates of transformed box vertices
     	for (Point2D point : this.vertices()) {
     		point = point.transform(trans);
-    		xmin = min(xmin, point.x());
-    		ymin = min(ymin, point.y());
-    		xmax = max(xmax, point.x());
-    		ymax = max(ymax, point.y());
+    		xmin = Math.min(xmin, point.x());
+    		ymin = Math.min(ymin, point.y());
+    		xmax = Math.max(xmax, point.x());
+    		ymax = Math.max(ymax, point.y());
     	}
     	
     	// create the resulting box

--- a/src/main/java/math/geom2d/circulinear/BoundaryPolyCirculinearCurve2D.java
+++ b/src/main/java/math/geom2d/circulinear/BoundaryPolyCirculinearCurve2D.java
@@ -44,22 +44,22 @@ implements CirculinearContinuousCurve2D, CirculinearContour2D {
      * collection of curves.
      * @since 0.8.1
      */
-	public static <T extends CirculinearContinuousCurve2D> 
+	/*public static <T extends CirculinearContinuousCurve2D>
 	BoundaryPolyCirculinearCurve2D<T>
 	create(Collection<T> curves) {
 		return new BoundaryPolyCirculinearCurve2D<T>(curves);
-	}
+	}*/
 
     /**
      * Static factory for creating a new BoundaryPolyCirculinearCurve2D from a
      * collection of curves.
      * @since 0.8.1
      */
-	public static <T extends CirculinearContinuousCurve2D> 
+	/*public static <T extends CirculinearContinuousCurve2D> 
 	BoundaryPolyCirculinearCurve2D<T>
 	create(Collection<T> curves, boolean closed) {
 		return new BoundaryPolyCirculinearCurve2D<T>(curves, closed);
-	}
+	}*/
 
     /**
      * Static factory for creating a new BoundaryPolyCirculinearCurve2D from an
@@ -158,7 +158,7 @@ implements CirculinearContinuousCurve2D, CirculinearContour2D {
 		BufferCalculator bc = BufferCalculator.getDefaultInstance();
 
     	return GenericCirculinearRing2D.create(
-    			bc.createContinuousParallel(this, dist).smoothPieces());
+    			bc.createContinuousParallel(this, dist).smoothPieces().toArray(new CirculinearElement2D[0]));
     }
     
 	

--- a/src/main/java/math/geom2d/circulinear/CirculinearContourArray2D.java
+++ b/src/main/java/math/geom2d/circulinear/CirculinearContourArray2D.java
@@ -46,10 +46,10 @@ extends ContourArray2D<T> implements CirculinearBoundary2D {
      * collection of curves.
      * @since 0.8.1
      */
-	public static <T extends CirculinearContour2D> 
+	/*public static <T extends CirculinearContour2D>
 	CirculinearContourArray2D<T> create(Collection<T> curves) {
 		return new CirculinearContourArray2D<T>(curves);
-	}
+	}*/
 
     /**
      * Static factory for creating a new CirculinearContourArray2D from an 
@@ -246,6 +246,6 @@ extends ContourArray2D<T> implements CirculinearBoundary2D {
             curves.add((CirculinearContinuousCurve2D) curve);
 
         // Create CurveSet for the result
-        return CirculinearCurveArray2D.create(curves);
+        return CirculinearCurveArray2D.create(curves.toArray(new CirculinearElement2D[0]));
     }
 }

--- a/src/main/java/math/geom2d/circulinear/CirculinearCurveArray2D.java
+++ b/src/main/java/math/geom2d/circulinear/CirculinearCurveArray2D.java
@@ -46,10 +46,10 @@ extends CurveArray2D<T> implements CirculinearCurveSet2D<T> {
      * curves.
      * @since 0.8.1
      */
-    public static <T extends CirculinearCurve2D> CirculinearCurveArray2D<T> create(
+    /*public static <T extends CirculinearCurve2D> CirculinearCurveArray2D<T> create(
     		Collection<T> curves) {
     	return new CirculinearCurveArray2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new CirculinearCurveArray2D from an array of

--- a/src/main/java/math/geom2d/circulinear/CirculinearCurves2D.java
+++ b/src/main/java/math/geom2d/circulinear/CirculinearCurves2D.java
@@ -87,7 +87,7 @@ public class CirculinearCurves2D {
 			}
 
 			// create the resulting CirculinearContinuousCurve2D
-			return CirculinearCurveArray2D.create(curves);
+			return CirculinearCurveArray2D.create(curves.toArray(new CirculinearElement2D[0]));
 		}
 
 		//TODO: throw exception ?
@@ -620,7 +620,7 @@ public class CirculinearCurves2D {
 
 			// create continuous curve formed only by circulinear elements
 			// and add it to the set of curves
-			contours.add(BoundaryPolyCirculinearCurve2D.create(elements, true));
+			contours.add(BoundaryPolyCirculinearCurve2D.create(elements.toArray(new CirculinearElement2D[0]), true));
 		}
 
 		return contours;
@@ -764,7 +764,7 @@ public class CirculinearCurves2D {
 
 			// create continuous curve formed only by circulinear elements
 			// and add it to the set of curves
-			contours.add(BoundaryPolyCirculinearCurve2D.create(elements, true));
+			contours.add(BoundaryPolyCirculinearCurve2D.create(elements.toArray(new CirculinearElement2D[0]), true));
 		}
 
 		// Process other curves, while there are intersections left
@@ -807,7 +807,7 @@ public class CirculinearCurves2D {
 
 			// create continuous curve formed only by circulinear elements
 			// and add it to the set of curves
-			contours.add(BoundaryPolyCirculinearCurve2D.create(elements, true));
+			contours.add(BoundaryPolyCirculinearCurve2D.create(elements.toArray(new CirculinearElement2D[0]), true));
 		}
 
 		return contours;

--- a/src/main/java/math/geom2d/circulinear/GenericCirculinearDomain2D.java
+++ b/src/main/java/math/geom2d/circulinear/GenericCirculinearDomain2D.java
@@ -65,7 +65,7 @@ implements CirculinearDomain2D {
 		return new GenericCirculinearDomain2D(
 				CirculinearContourArray2D.create(
 						CirculinearCurves2D.splitIntersectingContours(
-								newBoundary.continuousCurves())));
+								newBoundary.continuousCurves()).toArray(new CirculinearContour2D[0])));
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/math/geom2d/circulinear/GenericCirculinearRing2D.java
+++ b/src/main/java/math/geom2d/circulinear/GenericCirculinearRing2D.java
@@ -37,10 +37,10 @@ implements CirculinearRing2D {
      * curves.
      * @since 0.8.1
      */
-    public static <T extends CirculinearElement2D> GenericCirculinearRing2D
+    /*public static <T extends CirculinearElement2D> GenericCirculinearRing2D
     create(Collection<T> curves) {
     	return new GenericCirculinearRing2D(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new GenericCirculinearRing2D from an array of

--- a/src/main/java/math/geom2d/circulinear/PolyCirculinearCurve2D.java
+++ b/src/main/java/math/geom2d/circulinear/PolyCirculinearCurve2D.java
@@ -36,10 +36,10 @@ extends PolyOrientedCurve2D<T> implements CirculinearContinuousCurve2D {
      * collection of curves.
      * @since 0.8.1
      */
-    public static <T extends CirculinearContinuousCurve2D> 
+    /*public static <T extends CirculinearContinuousCurve2D> 
     PolyCirculinearCurve2D<T> create(Collection<T> curves) {
     	return new PolyCirculinearCurve2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new PolyCirculinearCurve2D from an array
@@ -56,10 +56,10 @@ extends PolyOrientedCurve2D<T> implements CirculinearContinuousCurve2D {
      * collection of curves and a flag indicating if the curve is closed.
      * @since 0.9.0
      */
-    public static <T extends CirculinearContinuousCurve2D> 
+    /*public static <T extends CirculinearContinuousCurve2D> 
     PolyCirculinearCurve2D<T> create(Collection<T> curves, boolean closed) {
     	return new PolyCirculinearCurve2D<T>(curves, closed);
-    }
+    }*/
     
     /**
      * Static factory for creating a new PolyCirculinearCurve2D from an array

--- a/src/main/java/math/geom2d/circulinear/buffer/BufferCalculator.java
+++ b/src/main/java/math/geom2d/circulinear/buffer/BufferCalculator.java
@@ -128,7 +128,7 @@ public class BufferCalculator {
 			parallelContours.add(contour.parallel(dist));
 		
 		// Create an agglomeration of the curves
-		return CirculinearContourArray2D.create(parallelContours);
+		return CirculinearContourArray2D.create(parallelContours.toArray(new CirculinearContour2D[0]));
 	}
 
 	public CirculinearContour2D createParallelContour(
@@ -148,7 +148,7 @@ public class BufferCalculator {
 			getParallelElements(contour, dist);
 		
 		// Create a new boundary with the set of parallel curves
-		return BoundaryPolyCirculinearCurve2D.create(parallelCurves, 
+		return BoundaryPolyCirculinearCurve2D.create(parallelCurves.toArray(new CirculinearContinuousCurve2D[0]),
 				contour.isClosed());
 	}
 	
@@ -170,7 +170,7 @@ public class BufferCalculator {
 		
 		// Create a new circulinear continuous curve with the set of parallel
 		// curves
-		return PolyCirculinearCurve2D.create(parallelCurves, curve.isClosed());
+		return PolyCirculinearCurve2D.create(parallelCurves.toArray(new CirculinearContinuousCurve2D[0]), curve.isClosed());
 	}
 	
 	private Collection<CirculinearContinuousCurve2D> getParallelElements(
@@ -294,7 +294,7 @@ public class BufferCalculator {
 		// All the rings are created, we can now create a new domain with the
 		// set of rings
 		return new GenericCirculinearDomain2D(
-				CirculinearContourArray2D.create(contours2));
+				CirculinearContourArray2D.create(contours2.toArray(new CirculinearContour2D[0])));
 	}
 	
 	/**
@@ -331,7 +331,7 @@ public class BufferCalculator {
 		}
 
 		return new GenericCirculinearDomain2D(
-				CirculinearContourArray2D.create(contours2));
+				CirculinearContourArray2D.create(contours2.toArray(new CirculinearContour2D[0])));
 	}
 
 	/**
@@ -503,9 +503,9 @@ public class BufferCalculator {
 		
 		// if the curve is closed, return an instance of GenericCirculinearRing2D
 		if (curve.isClosed())
-			return GenericCirculinearRing2D.create(curve.smoothPieces());
+			return GenericCirculinearRing2D.create(curve.smoothPieces().toArray(new CirculinearElement2D[0]));
 		
-		return BoundaryPolyCirculinearCurve2D.create(curve.smoothPieces());
+		return BoundaryPolyCirculinearCurve2D.create(curve.smoothPieces().toArray(new CirculinearContinuousCurve2D[0]));
 	}
 	
 	private double getDistanceCurveSingularPoints(

--- a/src/main/java/math/geom2d/curve/PolyCurve2D.java
+++ b/src/main/java/math/geom2d/curve/PolyCurve2D.java
@@ -56,10 +56,10 @@ public class PolyCurve2D<T extends ContinuousCurve2D> extends CurveArray2D<T>
      * curves.
      * @since 0.8.1
      */
-    public static <T extends ContinuousCurve2D> PolyCurve2D<T> create(
+    /*public static <T extends ContinuousCurve2D> PolyCurve2D<T> create(
     		Collection<T> curves) {
     	return new PolyCurve2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new PolyCurve2D from an array of

--- a/src/main/java/math/geom2d/domain/BoundaryPolyCurve2D.java
+++ b/src/main/java/math/geom2d/domain/BoundaryPolyCurve2D.java
@@ -50,10 +50,10 @@ public class BoundaryPolyCurve2D<T extends ContinuousOrientedCurve2D> extends
      * of curves.
      * @since 0.8.1
      */
-    public static <T extends ContinuousOrientedCurve2D> BoundaryPolyCurve2D<T> create(
+    /*public static <T extends ContinuousOrientedCurve2D> BoundaryPolyCurve2D<T> create(
     		Collection<T> curves) {
     	return new BoundaryPolyCurve2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new BoundaryPolyCurve2D from an array of

--- a/src/main/java/math/geom2d/domain/ContourArray2D.java
+++ b/src/main/java/math/geom2d/domain/ContourArray2D.java
@@ -54,10 +54,10 @@ implements Boundary2D {
      * contours.
      * @since 0.8.1
      */
-    public static <T extends Contour2D> ContourArray2D<T> create(
+    /*public static <T extends Contour2D> ContourArray2D<T> create(
     		Collection<T> curves) {
     	return new ContourArray2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new ContourArray2D from an array of

--- a/src/main/java/math/geom2d/domain/DomainArray2D.java
+++ b/src/main/java/math/geom2d/domain/DomainArray2D.java
@@ -4,7 +4,7 @@
  * 
  * Distributed under the LGPL License.
  *
- * Created: 17 août 10
+ * Created: 17 aoï¿½t 10
  */
 package math.geom2d.domain;
 
@@ -28,9 +28,9 @@ import math.geom2d.polygon.*;
 public class DomainArray2D<T extends Domain2D> extends ShapeArray2D<T> 
 implements DomainSet2D<T> {
 
-	public static <D extends Domain2D> DomainArray2D<D> create(Collection<D> array) {
+	/*public static <D extends Domain2D> DomainArray2D<D> create(Collection<D> array) {
 		return new DomainArray2D<D>(array);
-	}
+	}*/
 	
 	public static <D extends Domain2D> DomainArray2D<D> create(D... array) {
 		return new DomainArray2D<D>(array);

--- a/src/main/java/math/geom2d/domain/PolyOrientedCurve2D.java
+++ b/src/main/java/math/geom2d/domain/PolyOrientedCurve2D.java
@@ -66,10 +66,10 @@ public class PolyOrientedCurve2D<T extends ContinuousOrientedCurve2D> extends
      * curves.
      * @since 0.8.1
      */
-    public static <T extends ContinuousOrientedCurve2D> PolyOrientedCurve2D<T>
+    /*public static <T extends ContinuousOrientedCurve2D> PolyOrientedCurve2D<T>
     create(Collection<T> curves) {
     	return new PolyOrientedCurve2D<T>(curves);
-    }
+    }*/
     
     /**
      * Static factory for creating a new PolyOrientedCurve2D from an array of
@@ -96,10 +96,10 @@ public class PolyOrientedCurve2D<T extends ContinuousOrientedCurve2D> extends
      * curves and a flag indicating if the curve is closed or not.
      * @since 0.9.0
      */
-    public static <T extends ContinuousOrientedCurve2D> PolyOrientedCurve2D<T>
+    /*public static <T extends ContinuousOrientedCurve2D> PolyOrientedCurve2D<T>
     create(Collection<T> curves, boolean closed) {
     	return new PolyOrientedCurve2D<T>(curves, closed);
-    }
+    }*/
     
     /**
      * Static factory for creating a new PolyOrientedCurve2D from an array of

--- a/src/main/java/math/geom2d/polygon/LinearRing2D.java
+++ b/src/main/java/math/geom2d/polygon/LinearRing2D.java
@@ -201,7 +201,7 @@ public class LinearRing2D extends LinearCurve2D implements CirculinearRing2D {
     public CirculinearRing2D parallel(double dist) {
 		BufferCalculator bc = BufferCalculator.getDefaultInstance();
 		return GenericCirculinearRing2D.create(
-    			bc.createContinuousParallel(this, dist).smoothPieces());
+    			bc.createContinuousParallel(this, dist).smoothPieces().toArray(new CirculinearElement2D[0]));
     }
     
 	/* (non-Javadoc)

--- a/src/main/java/math/geom2d/polygon/MultiPolygon2D.java
+++ b/src/main/java/math/geom2d/polygon/MultiPolygon2D.java
@@ -10,6 +10,7 @@ import math.geom2d.AffineTransform2D;
 import math.geom2d.Box2D;
 import math.geom2d.GeometricObject2D;
 import math.geom2d.Point2D;
+import math.geom2d.circulinear.CirculinearContour2D;
 import math.geom2d.circulinear.CirculinearContourArray2D;
 import math.geom2d.circulinear.CirculinearDomain2D;
 import math.geom2d.circulinear.GenericCirculinearDomain2D;
@@ -338,7 +339,7 @@ public class MultiPolygon2D implements Domain2D, Polygon2D {
 	}
 
     public CirculinearContourArray2D<LinearRing2D> boundary() {
-        return CirculinearContourArray2D.create(rings);
+        return CirculinearContourArray2D.create(rings.toArray(new LinearRing2D[0]));
     }
 
 	/* (non-Javadoc)


### PR DESCRIPTION
  - incresed the source and target language to Java 1.8
  - explictly use Math.max/min rather than Double.max/min
  - Remove X.create(Colletion<T> a) as it doesn't compile.  Replaced it with horrible .toArray(new ExpectedType[0]), so you now have to explicitly choose the create method you want to use.

I'm not quire sure how the X.create(Collection<T> a) ever worked due to the type erasure rules in Java.  I'd love to know if/how it worked.  In which case I'll re-enable the code and take out the awful .toArray() calls.