### PR TITLE
Add gpcj as a maven dep, rather than a system dep.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,13 @@
 			<groupId>org.seisw</groupId>
 			<artifactId>gpcj</artifactId>
 			<version>2.2.0</version>
+			<!--
+				Rather than having a system path, install the jar using
+				$ mvn install:install-file -Dfile=lib/gpcj-2.2.0.jar -DgroupId=org.seisw -DartifactId=gpcj -Dversion=2.2.0 -Dpackaging=jar
+				this then allows us to shade the final jar properly.
 			<scope>system</scope>
 			<systemPath>${project.basedir}/lib/gpcj-2.2.0.jar</systemPath>
+			-->
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The gpcj jar is not available in Maven central, but it makes sense to either (a) include it in the javaGeom jar or (b) make your local maven cache aware of it.  This makes it easier for third party apps to use javaGeom without a hard dep on a copy of gpcj in their source tree.

This patch adds gpcj as a dep of javaGeom, with a comment explaining how to add the jar to the users' maven cache.  I think this is the least worst option in this case.
